### PR TITLE
support compiler hooks afterCompile where stats.toJson is undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,8 +41,8 @@ WebpackCopyOnPlugin.prototype.apply = function(compiler) {
     };
 
     compiler.plugin(eventHook, function(stats) {
-        const statsJson = stats.toJson();
-        const chunks = statsJson.chunks;
+        const statsJson = stats.toJson ? stats.toJson() : {};
+        const chunks = statsJson.chunks ? statsJson.chunks : [];
         chunks.forEach(function(chunk) {
             const chunkName = chunk.names[0];
             let mapping = mappings[chunkName];


### PR DESCRIPTION
Fixing: 
```
TypeError: stats.toJson is not a function
    at /Users/jjohn/www/GuaranteedRate.com-mod/node_modules/webpack-copy-on-plugin/index.js:44:33
    at AsyncSeriesHook.eval [as callAsync] (eval at create (/Users/jjohn/www/GuaranteedRate.com-mod/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:9:1)
    at AsyncSeriesHook.lazyCompileHook (/Users/jjohn/www/GuaranteedRate.com-mod/node_modules/tapable/lib/Hook.js:154:20)
    at compilation.seal.err (/Users/jjohn/www/GuaranteedRate.com-mod/node_modules/webpack/lib/Compiler.js:668:31)
    at AsyncSeriesHook.eval [as callAsync] (eval at create (/Users/jjohn/www/GuaranteedRate.com-mod/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:9:1)
    at AsyncSeriesHook.lazyCompileHook (/Users/jjohn/www/GuaranteedRate.com-mod/node_modules/tapable/lib/Hook.js:154:20)
    at hooks.optimizeAssets.callAsync.err (/Users/jjohn/www/GuaranteedRate.com-mod/node_modules/webpack/lib/Compilation.js:1385:35)
    at AsyncSeriesHook.eval [as callAsync] (eval at create (/Users/jjohn/www/GuaranteedRate.com-mod/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:9:1)
    at AsyncSeriesHook.lazyCompileHook (/Users/jjohn/www/GuaranteedRate.com-mod/node_modules/tapable/lib/Hook.js:154:20)
    at hooks.optimizeChunkAssets.callAsync.err (/Users/jjohn/www/GuaranteedRate.com-mod/node_modules/webpack/lib/Compilation.js:1376:32)
    at AsyncSeriesHook.eval [as callAsync] (eval at create (/Users/jjohn/www/GuaranteedRate.com-mod/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:9:1)
    at AsyncSeriesHook.lazyCompileHook (/Users/jjohn/www/GuaranteedRate.com-mod/node_modules/tapable/lib/Hook.js:154:20)
    at hooks.additionalAssets.callAsync.err (/Users/jjohn/www/GuaranteedRate.com-mod/node_modules/webpack/lib/Compilation.js:1371:36)
    at AsyncSeriesHook.eval [as callAsync] (eval at create (/Users/jjohn/www/GuaranteedRate.com-mod/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:9:1)
    at AsyncSeriesHook.lazyCompileHook (/Users/jjohn/www/GuaranteedRate.com-mod/node_modules/tapable/lib/Hook.js:154:20)
    at hooks.optimizeTree.callAsync.err (/Users/jjohn/www/GuaranteedRate.com-mod/node_modules/webpack/lib/Compilation.js:1367:32)
```

The `stats.toJson` part of the code is for the filematch regex, rather than the simpler `copyFolder` functionality. This just prevents the errors.

Meets my use case, and safe to merge. But probably some deeper error reporting would be the right thing to do.